### PR TITLE
Remove inline attribute on const item.

### DIFF
--- a/src/blake2.rs
+++ b/src/blake2.rs
@@ -5,7 +5,6 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-#[inline(always)]
 pub const SIGMA: [[usize; 16]; 10] = [
     [ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15],
     [14, 10,  4,  8,  9, 15, 13,  6,  1, 12,  0,  2, 11,  7,  5,  3],


### PR DESCRIPTION
The attribute `inline` is only intended for functions, but a bug in the Rust compiler failed to catch that in all cases. As of https://github.com/rust-lang/rust/issues/31769, this usage will cause builds to fail.
