### PR TITLE
Update arrayvec to 0.5.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ simd_asm = ["simd_opt"]
 std = []
 
 [dependencies]
-arrayvec = { version = "0.4.0", default-features = false }
+arrayvec = { version = "0.5.1", default-features = false }
 constant_time_eq = "0.1.0"
 
 [dev-dependencies]


### PR DESCRIPTION
This will also cancel the dependency of `nodrop`, which is deprecated there